### PR TITLE
relex T trait bound, make Weight trait depend on Iterator trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,7 @@ pub use roundrobin_weight::*;
 pub use smooth_weight::*;
 
 /// A common trait for weight algorithm.
-pub trait Weight {
-    type Item;
-
-    /// gets next selected item.
-    fn next(&mut self) -> Option<Self::Item>;
+pub trait Weight: Iterator {
     /// adds a weighted item for selection.
     fn add(&mut self, item: Self::Item, weight: isize);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@
 //!     }
 //! ```
 
-use std::collections::HashMap;
-
 pub mod random_weight;
 pub mod roundrobin_weight;
 pub mod smooth_weight;
@@ -33,21 +31,21 @@ pub use random_weight::*;
 pub use roundrobin_weight::*;
 pub use smooth_weight::*;
 
-// A common trait for weight algorithm.
+/// A common trait for weight algorithm.
 pub trait Weight {
     type Item;
 
-    // next gets next selected item.
+    /// gets next selected item.
     fn next(&mut self) -> Option<Self::Item>;
-    // add adds a weighted item for selection.
+    /// adds a weighted item for selection.
     fn add(&mut self, item: Self::Item, weight: isize);
 
-    // all returns all items.
-    fn all(&self) -> HashMap<Self::Item, isize>;
+    /// returns all items.
+    fn all(&self) -> impl Iterator<Item = (Self::Item, isize)> + '_;
 
-    // remove_all removes all weighted items.
+    /// removes all weighted items.
     fn remove_all(&mut self);
 
-    // reset resets the balancing algorithm.
+    /// resets the balancing algorithm.
     fn reset(&mut self);
 }

--- a/src/random_weight.rs
+++ b/src/random_weight.rs
@@ -26,24 +26,6 @@ impl<T: Clone> RandWeight<T> {
 }
 
 impl<T: Clone> Weight for RandWeight<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        if self.items.len() <= 1 {
-            return self.items.first().map(|item| item.item.clone());
-        }
-
-        let mut index = self.r.gen_range(0..self.sum_of_weights);
-        for item in &self.items {
-            index -= item.weight;
-            if index <= 0 {
-                return Some(item.item.clone());
-            }
-        }
-
-        self.items.last().map(|item| item.item.clone())
-    }
-
     fn add(&mut self, item: T, weight: isize) {
         let weight_item = RandWeightItem { item, weight };
 
@@ -62,9 +44,28 @@ impl<T: Clone> Weight for RandWeight<T> {
         self.r = rand::thread_rng();
     }
 
-    // reset resets the balancing algorithm.
     fn reset(&mut self) {
         self.r = rand::thread_rng();
+    }
+}
+
+impl<T: Clone> Iterator for RandWeight<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.items.len() <= 1 {
+            return self.items.first().map(|item| item.item.clone());
+        }
+
+        let mut index = self.r.gen_range(0..self.sum_of_weights);
+        for item in &self.items {
+            index -= item.weight;
+            if index <= 0 {
+                return Some(item.item.clone());
+            }
+        }
+
+        self.items.last().map(|item| item.item.clone())
     }
 }
 

--- a/src/random_weight.rs
+++ b/src/random_weight.rs
@@ -1,6 +1,5 @@
 use super::Weight;
 use rand::prelude::{Rng, ThreadRng};
-use std::{collections::HashMap, hash::Hash};
 
 #[derive(Clone, Debug)]
 struct RandWeightItem<T> {
@@ -12,31 +11,26 @@ struct RandWeightItem<T> {
 #[derive(Default)]
 pub struct RandWeight<T> {
     items: Vec<RandWeightItem<T>>,
-    n: usize,
     sum_of_weights: isize,
     r: ThreadRng,
 }
 
-impl<T: Clone + PartialEq + Eq + Hash> RandWeight<T> {
+impl<T: Clone> RandWeight<T> {
     pub fn new() -> Self {
         RandWeight {
             items: Vec::new(),
-            n: 0,
             sum_of_weights: 0,
             r: rand::thread_rng(),
         }
     }
 }
 
-impl<T: Clone + PartialEq + Eq + Hash> Weight for RandWeight<T> {
+impl<T: Clone> Weight for RandWeight<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        if self.n == 0 {
-            return None;
-        }
-        if self.n == 1 {
-            return Some(self.items[0].item.clone());
+        if self.items.len() <= 1 {
+            return self.items.first().map(|item| item.item.clone());
         }
 
         let mut index = self.r.gen_range(0..self.sum_of_weights);
@@ -47,30 +41,24 @@ impl<T: Clone + PartialEq + Eq + Hash> Weight for RandWeight<T> {
             }
         }
 
-        Some(self.items[self.n - 1].item.clone())
+        self.items.last().map(|item| item.item.clone())
     }
-    // add adds a weighted item for selection.
+
     fn add(&mut self, item: T, weight: isize) {
         let weight_item = RandWeightItem { item, weight };
 
         self.items.push(weight_item);
-        self.n += 1;
         self.sum_of_weights += weight;
     }
 
-    // all returns all items.
-    fn all(&self) -> HashMap<T, isize> {
-        let mut rt: HashMap<T, isize> = HashMap::new();
-        for w in &self.items {
-            rt.insert(w.item.clone(), w.weight);
-        }
-        rt
+    fn all(&self) -> impl Iterator<Item = (Self::Item, isize)> + '_ {
+        self.items
+            .iter()
+            .map(|item| (item.item.clone(), item.weight))
     }
 
-    // remove_all removes all weighted items.
     fn remove_all(&mut self) {
         self.items.clear();
-        self.n = 0;
         self.r = rand::thread_rng();
     }
 

--- a/src/roundrobin_weight.rs
+++ b/src/roundrobin_weight.rs
@@ -34,31 +34,6 @@ impl<T: Clone> RoundrobinWeight<T> {
 }
 
 impl<T: Clone> Weight for RoundrobinWeight<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        if self.items.len() <= 1 {
-            return self.items.first().map(|itme| itme.item.clone());
-        }
-
-        loop {
-            self.i = (self.i + 1) % (self.items.len() as isize);
-            if self.i == 0 {
-                self.cw -= self.gcd;
-                if self.cw <= 0 {
-                    self.cw = self.max_w;
-                    if self.cw == 0 {
-                        return None;
-                    }
-                }
-            }
-
-            if self.items[self.i as usize].weight >= self.cw {
-                return Some(self.items[self.i as usize].item.clone());
-            }
-        }
-    }
-    // add adds a weighted item for selection.
     fn add(&mut self, item: T, weight: isize) {
         let weight_item = RRWeightItem { item, weight };
 
@@ -96,6 +71,33 @@ impl<T: Clone> Weight for RoundrobinWeight<T> {
     fn reset(&mut self) {
         self.i = -1;
         self.cw = 0;
+    }
+}
+
+impl<T: Clone> Iterator for RoundrobinWeight<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.items.len() <= 1 {
+            return self.items.first().map(|itme| itme.item.clone());
+        }
+
+        loop {
+            self.i = (self.i + 1) % (self.items.len() as isize);
+            if self.i == 0 {
+                self.cw -= self.gcd;
+                if self.cw <= 0 {
+                    self.cw = self.max_w;
+                    if self.cw == 0 {
+                        return None;
+                    }
+                }
+            }
+
+            if self.items[self.i as usize].weight >= self.cw {
+                return Some(self.items[self.i as usize].item.clone());
+            }
+        }
     }
 }
 

--- a/src/smooth_weight.rs
+++ b/src/smooth_weight.rs
@@ -59,17 +59,6 @@ impl<T: Clone> SmoothWeight<T> {
 }
 
 impl<T: Clone> Weight for SmoothWeight<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        if self.items.len() <= 1 {
-            return self.items.first().map(|item| item.item.clone());
-        }
-
-        let rt = self.next_smooth_weighted()?;
-        Some(rt.item)
-    }
-    // add adds a weighted item for selection.
     fn add(&mut self, item: T, weight: isize) {
         let weight_item = SmoothWeightItem {
             item,
@@ -81,24 +70,34 @@ impl<T: Clone> Weight for SmoothWeight<T> {
         self.items.push(weight_item);
     }
 
-    // all returns all items.
     fn all(&self) -> impl Iterator<Item = (Self::Item, isize)> + '_ {
         self.items
             .iter()
             .map(|item| (item.item.clone(), item.weight))
     }
 
-    // remove_all removes all weighted items.
     fn remove_all(&mut self) {
         self.items.clear();
     }
 
-    // reset resets the balancing algorithm.
     fn reset(&mut self) {
         for w in &mut self.items {
             w.current_weight = 0;
             w.effective_weight = w.weight;
         }
+    }
+}
+
+impl<T: Clone> Iterator for SmoothWeight<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.items.len() <= 1 {
+            return self.items.first().map(|item| item.item.clone());
+        }
+
+        let rt = self.next_smooth_weighted()?;
+        Some(rt.item)
     }
 }
 


### PR DESCRIPTION
# relax T trait bound

make `fn all(&self)` return `impl Iterator<Item = (Self::Item, isize)> + '_` so the `T: Clone + PartialEq + Eq + Hash` limit can be relaxed

# make `Weight` trait depend on `Iterator` trait

it doesn't change the method signature, just move the implement to `Iterator` trait implement block, this change can allow user use `RandWeight` and others as an iterator